### PR TITLE
Fix missing CORS setup

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@ const app = require('express')();
 var cors = require('cors');
 const http = require('http').Server(app);
 
+// enable CORS for the HTTP routes as well
+app.use(cors());
+
 const io = require("socket.io")(http, {cors: {
 origin: ["https://plastyctoy.com", "http://localhost:8888"], // or "*"
 methods: ["GET", "POST"]}});


### PR DESCRIPTION
## Summary
- enable CORS middleware in Express server

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684608c794188330ac46d9ce48b5cd2d